### PR TITLE
Alcohol report, alcohol report page and trace function

### DIFF
--- a/environment/environment.yml
+++ b/environment/environment.yml
@@ -24,3 +24,4 @@ dependencies:
     - pytest-snapshot==0.9.0
     - scipy==1.15.2
     - itables==2.4.0
+    - great_tables==0.13.0

--- a/streamlit_app/alcohol_agents.py
+++ b/streamlit_app/alcohol_agents.py
@@ -10,6 +10,7 @@ from mesa.time import RandomActivation
 #from mesa.space import MultiGrid
 from mesa.datacollection import DataCollector
 #import random
+import os
 import streamlit as st
 from model_two_types_mecc import (PersonAgent
                                   , ServiceAgent
@@ -21,6 +22,28 @@ from model_two_types_mecc import (PersonAgent
 ##################################
 ### Person Agent Class
 ##################################
+
+output_path = os.path.join(os.getcwd(),'streamlit_app','outputs')
+print_output_file = os.path.join(output_path,"print_output.txt")
+
+def trace(msg):
+    """
+    Turning on and off tracing of agent actions.
+    """
+    TRACE = True 
+    OUTPUT = False
+    ## These CONTSTANTS should be set outside the function, but to keep it simple,
+    ## to toggle on/off in ONE place, I have added it here.
+    ## just import trace function in other files and replace print 
+    ## statements with trace.
+          
+    if OUTPUT:
+        with open(print_output_file, "a") as f:
+            print(msg, file=f)
+
+    if TRACE:
+        print(msg)
+        
 
 ## creates a subclass of person agent for the alcohol model
 class AlcoholModel_PersonAgent(PersonAgent):
@@ -125,7 +148,7 @@ class AlcoholModel_PersonAgent(PersonAgent):
                                                 self.post_intervention_sd_units),2)
             self.reduced_alcohol = self.alcohol_status['units_per_week'] - self.post_intervention_units
             self.alcohol_status['units_per_week'] = self.post_intervention_units
-            print(f" > Person {self.unique_id} alcohol units per week changed by " +
+            trace(f" > Person {self.unique_id} alcohol units per week changed by " +
                   f"{self.reduced_alcohol} to {self.alcohol_status['units_per_week']}")
         else:
             pass
@@ -181,7 +204,7 @@ class AlcoholModel_PersonAgent(PersonAgent):
 
     def visit(self,service,probability):
         if self.random.uniform(0,1) <= probability:
-            print(f" > Person {self.unique_id} visited a {service}")
+            trace(f" > Person {self.unique_id} visited a {service}")
             ## randomly selects a service agent
             ServiceAgent_list = [agent for agent in self.model.schedule.agents if isinstance(agent, AlcoholModel_ServiceAgent)]
             ServiceAgent_list = [agent for agent in ServiceAgent_list if agent.category == service]
@@ -209,7 +232,7 @@ class AlcoholModel_PersonAgent(PersonAgent):
 
     ## Defines actions at each step
     def step(self):
-        print(f"Person {self.unique_id}")
+        trace(f"Person {self.unique_id}")
         super().step()
         self.update_alcohol_status()
         #self.update_golden_window()
@@ -272,7 +295,7 @@ class AlcoholModel_ServiceAgent(ServiceAgent):
     @classmethod
     def describe(cls):
         """Class method to print class information."""
-        print(f"This is a service agent of the category {cls.category}")
+        trace(f"This is a service agent of the category {cls.category}")
 
 
     def intervention_effect(self,PersonAgent):
@@ -280,7 +303,7 @@ class AlcoholModel_ServiceAgent(ServiceAgent):
         self.successful_interventions_made += 1
 
         PersonAgent.alcohol_status["status"] = "Change"
-        print(f"    >   > Person {PersonAgent.unique_id} status is now *{PersonAgent.alcohol_status['status']}*")
+        trace(f"    >   > Person {PersonAgent.unique_id} status is now *{PersonAgent.alcohol_status['status']}*")
 
         ## no decay applied to effectiveness
         #PersonAgent.change_prob_contemplation =+ self.contemplation_intervention
@@ -307,20 +330,20 @@ class AlcoholModel_ServiceAgent(ServiceAgent):
     def perform_intervention(self, PersonAgent):
         ## check
         if PersonAgent.alcohol_status["status"] == "Change":
-            print(f"  > {self.category} did not do an intervention on Person {PersonAgent.unique_id}" +
+            trace(f"  > {self.category} did not do an intervention on Person {PersonAgent.unique_id}" +
                   f" because status is *{PersonAgent.alcohol_status['status']}*")
         else:
             ## adds 1 to the intervention count
             self.interventions_made += 1
 
             ## if the change probability is lower than the intervention,
-            print(f"  > {self.category} attempted an intervention on Person {PersonAgent.unique_id}")
+            trace(f"  > {self.category} attempted an intervention on Person {PersonAgent.unique_id}")
 
             if PersonAgent.random.uniform(0, 1) <= PersonAgent.prob_receptive:
-                print(f"    >   > Person {PersonAgent.unique_id} is in receptive to intervention")
+                trace(f"    >   > Person {PersonAgent.unique_id} is in receptive to intervention")
                 self.intervention_effect(PersonAgent)
             else:
-                print(f"    >   > Person {PersonAgent.unique_id} is not receptive to intervention")
+                trace(f"    >   > Person {PersonAgent.unique_id} is not receptive to intervention")
 
         #    self.intervention_effect(PersonAgent)        
         #if PersonAgent.alcohol_status["in window"]:
@@ -536,7 +559,7 @@ class Alcohol_MECC_Model(MECC_Model):
         self.schedule = RandomActivation(self)
 
         ## Create person agents
-        print('\n\n*** Person Set-Up ***')
+        trace('\n\n*** Person Set-Up ***')
         for i in range(self.N_people):
             self.initial_units_per_week = round(self.random.normalvariate(
                                                     self.initial_units_per_week_mean
@@ -570,7 +593,7 @@ class Alcohol_MECC_Model(MECC_Model):
                             , post_intervention_sd_units = self.post_intervention_sd_units  
                             )
             self.schedule.add(a)
-            print(f'Person {i} created. Initial alcohol per week: {self.initial_units_per_week}')
+            trace(f'Person {i} created. Initial alcohol per week: {self.initial_units_per_week}')
 
         ## Create service agents
         for i, service in enumerate(self.services_list,start=1):

--- a/streamlit_app/alcohol_mecc_model.py
+++ b/streamlit_app/alcohol_mecc_model.py
@@ -8,8 +8,9 @@ from alcohol_outputs import create_population_figure,create_intervention_figure,
 import os
 import shutil
 import json
-from alcohol_agents import Alcohol_MECC_Model
+from alcohol_agents import Alcohol_MECC_Model, trace
 from alcohol_parameters import init_parameters
+
 
 ######################################################
 
@@ -173,9 +174,9 @@ with tab1:
                 progress = (step + 1) / st.session_state.num_steps
                 progress_bar.progress(progress)
 
-            print(f'\n\n*** No MECC - Step {step} ***')
+            trace(f'\n\n*** No MECC - Step {step} ***')
             data_no_mecc = run_simulation_step(model_no_mecc)
-            print(f'\n\n*** MECC Trained - Step {step} ***')            
+            trace(f'\n\n*** MECC Trained - Step {step} ***')            
             data_mecc = run_simulation_step(model_mecc)
 
             fig1 = create_population_figure(data_no_mecc, data_mecc, step)
@@ -238,7 +239,7 @@ with tab1:
         result.drop('p-value',axis=1,inplace=True)
 
         ## prints results to console for testing     
-        print(result)   
+        trace(result)   
 
         ## seperates results into sub tables
         result_total = result.iloc[result.index.str.contains('Total')].copy()
@@ -267,17 +268,29 @@ with tab1:
            
         ## save csv files for use in quarto
         result_total_file = os.path.join(output_path,'result_total.csv')
-        result_total.to_csv(result_total_file, index=True)
+        result_total.to_csv(result_total_file
+                            , index=True
+                            , index_label='Metric'
+                            , encoding="utf-8") ## encoding to allow for χ² charater to be displayed in quarto html
         
         result_contact_file = os.path.join(output_path,'result_contact.csv')
-        result_contact.to_csv(result_contact_file, index=True)
+        result_contact.to_csv(result_contact_file
+                              , index=True
+                              , index_label='Service'
+                              , encoding="utf-8") ## encoding to allow for χ² charater to be displayed in quarto html
         
         result_successful_file = os.path.join(output_path,'result_successful.csv')
-        result_successful.to_csv(result_successful_file, index=True)
+        result_successful.to_csv(result_successful_file
+                                 , index=True
+                                 , index_label='Service'
+                                 , encoding="utf-8") ## encoding to allow for χ² charater to be displayed in quarto html
          
         result_intervention_file = os.path.join(output_path,'result_intervention.csv')
-        result_intervention.to_csv(result_intervention_file, index=True)
-
+        result_intervention.to_csv(result_intervention_file
+                                   , index=True
+                                   , index_label='Service'
+                                   , encoding="utf-8") ## encoding to allow for χ² charater to be displayed in quarto html
+ 
 
 ######################################################
         st.markdown("### Raw Data")      

--- a/streamlit_app/alcohol_sim_report.qmd
+++ b/streamlit_app/alcohol_sim_report.qmd
@@ -41,8 +41,11 @@ execute:
 import pandas as pd
 import json
 import plotly.graph_objects as go
-# import great_tables as GT
-import itables
+from great_tables import GT
+
+# Load report preferences data from JSON
+with open("./outputs/report_preferences.json", "r") as f:
+    report_preferences = json.load(f)
 
 # Load session data from JSON
 with open("./outputs/session_data.json", "r") as f:
@@ -51,14 +54,11 @@ with open("./outputs/session_data.json", "r") as f:
 data_no_mecc = pd.read_csv("./outputs/data_no_mecc.csv")
 data_mecc = pd.read_csv("./outputs/data_mecc.csv")
 
-## iniate itables
-itables.init_notebook_mode(all_interactive=True)
-
+## Use this for debugging
+# print("Report section flags:", json.dumps(report_preferences, indent=2))
 ```
 
 # Alcohol Advice Model with MECC Training
-
-## Simulation Results
 
 ```{python}
 #| echo: false
@@ -67,18 +67,22 @@ from alcohol_outputs import create_population_figure
 from alcohol_outputs import create_intervention_figure
 from alcohol_outputs import create_intervention_decay_figure
 
-step = len(data_no_mecc) - 1
-fig1 = create_population_figure(data_no_mecc, data_mecc, step)
-fig1.show()
+if report_preferences["include_charts"]:
+    from IPython.display import Markdown
+    display(Markdown('## Simulation Charts'))
 
-fig2 = create_intervention_figure(data_no_mecc, data_mecc, step,'Contacts')
-fig2.show()
+    step = len(data_no_mecc) - 1
+    fig1 = create_population_figure(data_no_mecc, data_mecc, step)
+    fig1.show()
 
-fig3 = create_intervention_figure(data_no_mecc, data_mecc, step,'Interventions')
-fig3.show()
+    fig2 = create_intervention_figure(data_no_mecc, data_mecc, step,'Contacts')
+    fig2.show()
 
-fig4 = create_intervention_decay_figure(data_no_mecc, data_mecc, step)
-fig4.show()
+    fig3 = create_intervention_figure(data_no_mecc, data_mecc, step,'Interventions')
+    fig3.show()
+
+    fig4 = create_intervention_decay_figure(data_no_mecc, data_mecc, step)
+    fig4.show()
 ```
 
 ## Final Statistics
@@ -88,11 +92,18 @@ fig4.show()
 ```{python}
 #| echo: false
 #| label: Total_section
-#from itables import show
 
-result_total = pd.read_csv("./outputs/result_total.csv",index_col=0)
-
-itables.show(result_total, html=False)
+# if report_preferences["include_final_stats"]:
+result_total = pd.read_csv("./outputs/result_total.csv"
+                                    , encoding="utf-8" ## encoding to allow for χ² charater to be displayed in quarto html
+                                    , index_col=0)
+result_total = result_total.reset_index()
+(
+    GT(result_total)
+    .opt_stylize(style=4, color='blue',
+    add_row_striping=True)
+    .fmt_number(columns=["No MECC Training", "MECC Trained"], decimals=0)
+)
 
 ```
 
@@ -102,9 +113,20 @@ itables.show(result_total, html=False)
 #| echo: false
 #| label: Contacts_by_Services_section
 
-result_contact = pd.read_csv("./outputs/result_contact.csv",index_col=0)
+# if report_preferences["include_final_stats"]:
+result_contact = pd.read_csv("./outputs/result_contact.csv"
+                                    , encoding="utf-8" ## encoding to allow for χ² charater to be displayed in quarto html
+                                    , index_col=0)
 
-itables.show(result_contact)
+result_contact = result_contact.reset_index()
+
+(
+    GT(result_contact)
+    .opt_stylize(style=4, color='blue',
+    add_row_striping=True)
+    .fmt_number(columns=["No MECC Training", "MECC Trained"], decimals=0)
+
+)
 
 ```
 
@@ -114,10 +136,19 @@ itables.show(result_contact)
 #| echo: false
 #| label: Sucessful_Interventions_by_Services_section
 
+# if report_preferences["include_final_stats"]:
 result_successful = pd.read_csv("./outputs/result_successful.csv"
-                                ,index_col=0)
+                                    , encoding="utf-8" ## encoding to allow for χ² charater to be displayed in quarto html
+                                    , index_col=0)
 
-itables.show(result_successful)
+result_successful = result_successful.reset_index()
+
+(
+    GT(result_successful)
+    .opt_stylize(style=4, color='blue',
+    add_row_striping=True)
+    .fmt_number(columns=["No MECC Training", "MECC Trained"], decimals=0)
+)
 
 ```
 
@@ -127,55 +158,64 @@ itables.show(result_successful)
 #| echo: false
 #| label: All_Interventions_by_Services_section
 
+# if report_preferences["include_final_stats"]:
 result_intervention = pd.read_csv("./outputs/result_intervention.csv"
-                                    ,index_col=0)
+                                    , encoding="utf-8" ## encoding to allow for χ² charater to be displayed in quarto html
+                                    , index_col=0)
 
-itables.show(result_intervention)
+result_intervention = result_intervention.reset_index()
+
+(
+    GT(result_intervention)
+    .opt_stylize(style=4, color='blue',
+    add_row_striping=True)
+    .fmt_number(columns=["No MECC Training", "MECC Trained"], decimals=0)
+)
 
 ```
 
-## Toy MECC Parameters
+## Simulation Parameters
 
 ### Population Parameters
  - Number of People: **`{python} session_data["N_people"]`** 
  - Chance that a person is receptive to an intervention: **`{python} session_data["prob_receptive"]`**
-
-<!-- ### Stages of Change
- - Chance that a pre-Contemplation person not in a golden window is receptive to an intervention: **`{python} session_data["prob_receptive"]`**
- - Periods before chances reset to base (the golden window): **`{python} session_data["golden_window"]`**
-
-### Stages of Change - Base Positive Change Chance
- - Base Pre-Contemplation to Contemplation chance: **`{python} session_data["change_prob_contemplation"]`**
- - Base Contemplation to Preparation chance: **`{python} session_data["change_prob_preparation"]`**
- - Base Preparation to Action chance: **`{python} session_data["change_prob_action"]`**
-
-### Stages of Change - Lapse Chance
- - Base Contemplation to Pre-Contemplation lapse chance: **`{python} session_data["lapse_prob_precontemplation"]`**
- - Base Preparation to Contemplation lapse chance: **`{python} session_data["lapse_prob_contemplation"]`**
- - Base Action to Preparation lapse chance: **`{python} session_data["lapse_prob_preparation"]`**
--->
 
 ### Services
 ```{python}
 #| echo: false
 #| label: service_parameters
 
+# if report_preferences["include_sim_param"]:
 alcohol_services_edit = pd.read_csv("./outputs/alcohol_services_edit.csv"
-                                    ,index_col=0)
+                                    , encoding="utf-8" ## encoding to allow for χ² charater to be displayed in quarto html
+                                    , index_col=0)
 
-itables.show(alcohol_services_edit)
+alcohol_services_edit = alcohol_services_edit.reset_index()
+
+(
+    GT(alcohol_services_edit)
+    .opt_stylize(style=4, color='blue',
+    add_row_striping=True)
+    
+)
+
 
 ```
 
-### Simulation Parameters
+### Model Parameters
  - Random Seed: **`{python} session_data["model_seed"]`**
  - Number of Months to Simulate: **`{python} session_data["num_steps"]`**
  - Animation Speed (seconds): **`{python} session_data["animation_speed"]`**
 
 
-## Logic Diagram
+```{python}
+#| echo: false
+#| fig-align: center
+#| label: logic diagram
+#| output: asis  # Prevents cell wrapper from appearing
 
-![](../alcohol_logic_diagram.png){.r-stretch  fig-align="center"}
-
-
-<!-- {'model_seed': 42, 'N_people': 50, 'N_service': 1, 'initial_smoking_prob': 0.5, 'visit_prob': 0.1, 'quit_attempt_prob': 0.01, 'base_smoke_relapse_prob': 0.01, 'base_make_intervention_prob': 0.1, 'mecc_effect': 0.9, 'intervention_effect': 1.1, 'num_steps': 24, 'animation_speed': 0, 'iterations': 100, 'prob_receptive': 0.75, 'change_prob_contemplation': 0.01, 'change_prob_preparation': 0.01, 'change_prob_action': 0.01, 'lapse_prob_precontemplation': 0.01, 'lapse_prob_contemplation': 0.01, 'lapse_prob_preparation': 0.01, 'golden_window': 3, 'contemplation_intervention': {'Job Centre': 0.5, 'Benefits Office': 0.5, 'Housing Officer': 0.5, 'Community Hub': 0.5, 'Pharmacy': 0.5, 'GP Practice': 0.5}, 'preparation_intervention': {'Job Centre': 0.5, 'Benefits Office': 0.5, 'Housing Officer': 0.5, 'Community Hub': 0.5, 'Pharmacy': 0.5, 'GP Practice': 0.5}, 'action_intervention': {'Job Centre': 0.5, 'Benefits Office': 0.5, 'Housing Officer': 0.5, 'Community Hub': 0.5, 'Pharmacy': 0.5, 'GP Practice': 0.5}} -->
+if report_preferences["include_ld"]:
+    from IPython.display import Image, Markdown
+    display(Markdown('## Logic Diagram'))
+    display(Image(filename="../alcohol_logic_diagram.png", width="100%"))
+```

--- a/streamlit_app/alcohol_sim_report_page.py
+++ b/streamlit_app/alcohol_sim_report_page.py
@@ -21,11 +21,11 @@ if not st.session_state.simulation_completed:
     st.info("The generate report button will only appear once a simulation has been successfully run.")
 
 ## checkbox options - currently not being utilised.
-st.subheader("Select Report Sections:")
-incl_charts = st.checkbox("Include Charts Section", value=True,disabled=True)
-incl_final_stats = st.checkbox("Include Final Statistics Section", value=True,disabled=True)
-incl_sim_param = st.checkbox("Include Simulation Parameters Section", value=True,disabled=True)
-incl_ld = st.checkbox("Include Logic Diagram", value=True,disabled=True)
+st.subheader("Include Sections:")
+incl_charts = st.checkbox("Include Charts", value=True,disabled=False)
+# incl_final_stats = st.checkbox("Include Final Statistics Section", value=True,disabled=False)
+# incl_sim_param = st.checkbox("Include Simulation Parameters Section", value=True,disabled=False)
+incl_ld = st.checkbox("Include Logic Diagram", value=True,disabled=False)
        
         
 if st.session_state.simulation_completed:
@@ -75,6 +75,18 @@ if st.session_state.simulation_completed:
         html_filename = os.path.basename(qmd_filename).replace('.qmd', '.html')
         dest_html_path = os.path.join(output_dir,html_filename)
 
+        # save report preferences to json file to be used later for the quarto report
+        report_preferences = {
+            "include_charts": incl_charts,
+            # "include_final_stats": incl_final_stats,
+            # "include_sim_param": incl_sim_param,
+            "include_ld": incl_ld
+        }
+        report_preferences_path = os.path.join(output_path,'report_preferences.json')
+        with open(report_preferences_path, "w") as f:
+            json.dump(report_preferences, f, indent=4)
+
+
         try:
             ## forces result to be html
             result = subprocess.run(["quarto"
@@ -87,7 +99,7 @@ if st.session_state.simulation_completed:
                                     , capture_output=True
                                     , text=True)
             if os.path.exists(dest_html_path):
-                with open(dest_html_path, "r") as f:
+                with open(dest_html_path, "r", encoding="utf-8") as f: ## encoding to allow for χ² charater to be displayed in quarto html report
                     html_data = f.read()
 
                 report_message.success("Report ready for download!")
@@ -101,7 +113,6 @@ if st.session_state.simulation_completed:
                         "simulation_completed": False
                     })
                 )
-                # st.balloons()
             else:
                 report_message.error("Report failed to generate.")
                 st.code(result.stderr or "No error message available.")


### PR DESCRIPTION
1. Implemented the use of great_tables for the quarto alochol report 
2. Interface between quarto report and app, so user can choose to include the reslt charts and logic diagram. Currently the tables and parameters will always be included in the report.
3. Added a trace/print toggle feature to the model. The toggle is not available in the front end of the app though. The toggle allows the print statement to the terminal to be turned on/off in one place with also an option to output the print statements to a txt file. 